### PR TITLE
Add Ubuntu build-and-test pipeline

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -32,5 +32,5 @@ jobs:
 
       - name: Run tests
         run: |
-          cp build/3rd/SDL/SDL3.so ./
+          export LD_LIBRARY_PATH=${{ github.workspace }}/build/SDL3:$LD_LIBRARY_PATH
           ctest --test-dir build/tests --output-on-failure


### PR DESCRIPTION
This PR adds a CI pipeline to automate building and testing, showing a failure if any of the tests fail or if the build itself fails.